### PR TITLE
Introduce annotations to control hints

### DIFF
--- a/src/Annotation.php
+++ b/src/Annotation.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Pahout;
+
+use Pahout\Annotation\Base;
+use Pahout\Annotation\Rebel;
+
+/**
+* Annotation factory
+*
+* Get the comment token from the source code
+* and generate the appropriate annotation instance.
+*/
+class Annotation
+{
+    /**
+    * Annotation facotry method
+    *
+    * Get tokens from the source code by `token_get_all`
+    * and return an array of the obtained annotation instance.
+    *
+    * @param string $filename A file name.
+    * @param string $source   A body of file.
+    * @return Base[] List of annotation instance.
+    */
+    public static function create(string $filename, string $source): array
+    {
+        $annotations = [];
+
+        $tokens = token_get_all($source);
+        $comments = array_filter($tokens, function ($token) {
+            return in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true);
+        });
+
+        foreach ($comments as $comment) {
+            $rebel = Rebel::create($comment[1], $comment[2], $filename);
+            if ($rebel) {
+                $annotations[] = $rebel;
+            }
+        }
+
+        return $annotations;
+    }
+}

--- a/src/Annotation/Base.php
+++ b/src/Annotation/Base.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Pahout\Annotation;
+
+use Pahout\Hint;
+
+/**
+* Annotation abstract class
+*
+* Annotation must have a range of comments and a body.
+* It also has a method to determine the influence range
+* calculated from them.
+*/
+abstract class Base
+{
+    /** @var string A body of annotation */
+    protected $body;
+    /** @var integer The number of start line in the comment including annotation */
+    protected $start_line;
+    /** @var integer The number of end line in the comment including annotation */
+    protected $end_line;
+    /** @var string A file name */
+    protected $filename;
+
+    /**
+    * Annotation constructor
+    *
+    * @param string  $body       A body of annotation.
+    * @param integer $start_line The number of start line in the comment including annotation.
+    * @param integer $end_line   The number of end line in the comment including annotation.
+    * @param string  $filename   A file name.
+    */
+    public function __construct(string $body, int $start_line, int $end_line, string $filename)
+    {
+        $this->body = $body;
+        $this->start_line = $start_line;
+        $this->end_line = $end_line;
+        $this->filename = $filename;
+    }
+
+    /**
+    * Determine whether hint is target of annotation
+    *
+    * @param Hint $hint An instance of Hint.
+    * @return boolean If the hint is affected by this annotion, true, otherwise false.
+    */
+    abstract public function isAffected(Hint $hint): bool;
+}

--- a/src/Annotation/Rebel.php
+++ b/src/Annotation/Rebel.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Pahout\Annotation;
+
+use Pahout\Hint;
+
+/**
+* Rebel annocation
+*
+* For example, When there is a comment in a format like
+* `@rebel ToolName`, Pahout ignores the tool's hint.
+*/
+class Rebel extends Base
+{
+    /**
+    * Annotation factory
+    *
+    * If the comment contains `@rebel` annotation,
+    * this method creates an annotation instance.
+    *
+    * @param string  $comment    A body of comment.
+    * @param integer $start_line The number of comment's start line.
+    * @param string  $filename   The file name including the comment.
+    * @return null|Rebel If the comment contains rebel annotation, its instance, otherwise null.
+    */
+    public static function create(string $comment, int $start_line, string $filename): ?Rebel
+    {
+        if (preg_match('/@rebel\s+([^\s]+)/', $comment, $match) === 1) {
+            return new Rebel(
+                $match[1],
+                $start_line,
+                $start_line + substr_count($comment, PHP_EOL),
+                $filename
+            );
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Determine whether hint is target of annotation
+    *
+    * It checks file name, hint type, and the range of comments.
+    *
+    * @param Hint $hint An instance of Hint.
+    * @return boolean If the hint is affected by this annotion, true, otherwise false.
+    */
+    public function isAffected(Hint $hint): bool
+    {
+        return $hint->filename === $this->filename
+            && $hint->type === $this->body
+            && ($this->start_line - 1) <= $hint->lineno
+            && $hint->lineno <= ($this->end_line + 1);
+    }
+}

--- a/src/Annotation/Rebel.php
+++ b/src/Annotation/Rebel.php
@@ -3,6 +3,7 @@
 namespace Pahout\Annotation;
 
 use Pahout\Hint;
+use Pahout\Logger;
 
 /**
 * Rebel annocation
@@ -26,12 +27,11 @@ class Rebel extends Base
     public static function create(string $comment, int $start_line, string $filename): ?Rebel
     {
         if (preg_match('/@rebel\s+([^\s]+)/', $comment, $match) === 1) {
-            return new Rebel(
-                $match[1],
-                $start_line,
-                $start_line + substr_count($comment, PHP_EOL),
-                $filename
-            );
+            $body = $match[1];
+            $end_line = $start_line + substr_count($comment, PHP_EOL);
+
+            Logger::getInstance()->debug("Rebel annotation found: body=$body start=$start_line end=$end_line");
+            return new Rebel($body, $start_line, $end_line, $filename);
         } else {
             return null;
         }

--- a/tests/Annotation/RebelTest.php
+++ b/tests/Annotation/RebelTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Pahout\Test\Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Pahout\Annotation\Rebel;
+use Pahout\Hint;
+use Pahout\Logger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class RebelAnnotationTest extends TestCase
+{
+    public function setUp()
+    {
+        Logger::getInstance(new ConsoleOutput());
+        $this->rebel = new Rebel("MultipleCatch", 12, 15, './test.php');
+    }
+
+    public function test_line_is_affected()
+    {
+        $this->assertFalse($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './test.php',
+            10,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+
+        $this->assertTrue($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './test.php',
+            11,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+
+        $this->assertTrue($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './test.php',
+            13,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+
+        $this->assertTrue($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './test.php',
+            16,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+
+        $this->assertFalse($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './test.php',
+            17,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+    }
+
+    public function test_type_is_affected()
+    {
+        $this->assertFalse($this->rebel->isAffected(new Hint(
+            'NullCoalescingOperator',
+            'Use null coalecing operator instead of ternary operator.',
+            './test.php',
+            13,
+            Hint::DOCUMENT_LINK.'/NullCoalescingOperator.md'
+        )));
+
+        $this->assertTrue($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './test.php',
+            13,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+    }
+
+    public function test_filename_is_affected()
+    {
+        $this->assertFalse($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './vendor.php',
+            13,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+
+        $this->assertTrue($this->rebel->isAffected(new Hint(
+            'MultipleCatch',
+            'A catch block may specify multiple exceptions.',
+            './test.php',
+            13,
+            Hint::DOCUMENT_LINK.'/MultipleCatch.md'
+        )));
+    }
+}

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pahout\Test;
+
+use PHPUnit\Framework\TestCase;
+use Pahout\Annotation;
+use Pahout\Annotation\Rebel;
+use Pahout\Logger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class AnnotationTest extends TestCase
+{
+    public function setUp()
+    {
+        Logger::getInstance(new ConsoleOutput());
+    }
+
+    public function test_create()
+    {
+        $code = <<<'CODE'
+<?php
+
+/** @rebel SingleLineDocComment */
+$str = file_get_contents('.php-version');
+/**
+* This is multiple document comment.
+*
+* @suppress PhanComment
+* @rebel MultipleDocComment
+*
+* This is multiple document comment.
+*/
+echo $str; # @rebel SingleLineComment
+CODE;
+        $annotates = Annotation::create('./test.php', $code);
+        $this->assertEquals($annotates, [
+            new Rebel("SingleLineDocComment", 3, 3, './test.php'),
+            new Rebel("MultipleDocComment", 5, 12, './test.php'),
+            new Rebel("SingleLineComment", 13, 13, './test.php')
+        ]);
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -303,4 +303,27 @@ OUTPUT;
             chdir($work_dir);
         }
     }
+
+    public function test_rebel_annotations()
+    {
+        $work_dir = getcwd();
+        try {
+            chdir(self::FIXTURE_PATH.'/rebel_annotations');
+            $command = new CommandTester(new Check());
+            $command->execute([]);
+
+            $expected = <<<OUTPUT
+./test.php:6
+\tShortArraySyntax: Use [...] syntax instead of array(...) syntax. [https://github.com/wata727/pahout/blob/master/docs/ShortArraySyntax.md]
+
+1 files checked, 1 hints detected.
+
+OUTPUT;
+
+            $this->assertEquals($expected, $command->getDisplay());
+            $this->assertEquals(Check::EXIT_CODE_HINT_FOUND, $command->getStatusCode());
+        } finally {
+            chdir($work_dir);
+        }
+    }
 }

--- a/tests/fixtures/rebel_annotations/test.php
+++ b/tests/fixtures/rebel_annotations/test.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @rebel ShortArraySyntax */
+$array = array(1, 2, 3);
+
+$array = array(1, 2, 3); // ShortArraySyntax
+
+/**
+* @rebel ShortArraySyntax
+*/
+$array = array(1, 2, 3);
+
+$array = array(1, 2, 3); # @rebel ShortArraySyntax


### PR DESCRIPTION
Often we want to ignore hints that occur on a particular line. In such a case, by using the annotation, it makes it possible to "rebel" against the hint.

```php
<?php
/**
* @rebel RedundantTernaryOperator
*/
$checked = $a === $b ? true : false;
```

```php
<?php
/** @rebel RedundantTernaryOperator */
$checked = $a === $b ? true : false;
```

```php
<?php
$checked = $a === $b ? true : false; # @rebel RedundantTernaryOperator
```

This annotation works for lines. In other words, it does not work for file, class and method unit.
