### PR TITLE
Change the message of SyntaxError

### DIFF
--- a/docs/SyntaxError.md
+++ b/docs/SyntaxError.md
@@ -7,7 +7,7 @@ This is because when a parse error occurs, it does not affect the confirmation o
 
 ```php
 <?php
-funcion f[] ( ... ) // SyntaxError: syntax error, unexpected 'f' (T_STRING)
+funcion f[] ( ... ) // SyntaxError: Syntax error occurred.
 ```
 
 ## After

--- a/src/Pahout.php
+++ b/src/Pahout.php
@@ -75,8 +75,8 @@ class Pahout
                 if (!in_array('SyntaxError', Config::getInstance()->ignore_tools, true)) {
                     $this->hints[] = new Hint(
                         'SyntaxError',
-                        $exception->getMessage(),
-                        $exception->getFile(),
+                        'Syntax error occurred.',
+                        $file,
                         $exception->getLine(),
                         Hint::DOCUMENT_LINK."/SyntaxError.md"
                     );

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -32,7 +32,7 @@ class IntegrationTest extends TestCase
 \tShortArraySyntax: Use [...] syntax instead of array(...) syntax. [https://github.com/wata727/pahout/blob/master/docs/ShortArraySyntax.md]
 
 ./syntax_error.php:3
-\tSyntaxError: syntax error, unexpected 'f' (T_STRING) [https://github.com/wata727/pahout/blob/master/docs/SyntaxError.md]
+\tSyntaxError: Syntax error occurred. [https://github.com/wata727/pahout/blob/master/docs/SyntaxError.md]
 
 ./test.php:3
 \tShortArraySyntax: Use [...] syntax instead of array(...) syntax. [https://github.com/wata727/pahout/blob/master/docs/ShortArraySyntax.md]
@@ -99,7 +99,7 @@ OUTPUT;
 
             $expected = <<<OUTPUT
 ./syntax_error.php:3
-\tSyntaxError: syntax error, unexpected 'f' (T_STRING) [https://github.com/wata727/pahout/blob/master/docs/SyntaxError.md]
+\tSyntaxError: Syntax error occurred. [https://github.com/wata727/pahout/blob/master/docs/SyntaxError.md]
 
 3 files checked, 1 hints detected.
 
@@ -148,7 +148,7 @@ OUTPUT;
 
             $expected = <<<OUTPUT
 ./syntax_error.php:3
-\tSyntaxError: syntax error, unexpected 'f' (T_STRING) [https://github.com/wata727/pahout/blob/master/docs/SyntaxError.md]
+\tSyntaxError: Syntax error occurred. [https://github.com/wata727/pahout/blob/master/docs/SyntaxError.md]
 
 ./test.php:3
 \tShortArraySyntax: Use [...] syntax instead of array(...) syntax. [https://github.com/wata727/pahout/blob/master/docs/ShortArraySyntax.md]
@@ -282,7 +282,7 @@ OUTPUT;
                     ),
                     new Hint(
                         'SyntaxError',
-                        "syntax error, unexpected 'f' (T_STRING)",
+                        "Syntax error occurred.",
                         './syntax_error.php',
                         3,
                         Hint::DOCUMENT_LINK.'/SyntaxError.md'


### PR DESCRIPTION
The message of SyntaxError tool used an exception message. However, this message depends on a version of PHP. So, tests may not pass depending on versions of PHP.

Change the message so that we can pass tests in all environments.
