### PR TITLE
Add AmbiguousReturnCheck

### DIFF
--- a/docs/AmbiguousReturnCheck.md
+++ b/docs/AmbiguousReturnCheck.md
@@ -1,0 +1,41 @@
+# AmbiguousReturnCheck
+
+In functions returning falsy value, do not compare return values ​​without using the `===` operator.
+
+For example, `strpos` returns integer or false, so if you check this with the `==` operator, when returning 0, the condition is the same as false.
+
+The following functions are checked:
+
+- strpos
+- mb_strpos
+- stripos
+- mb_stripos
+- strrpos
+- mb_strrpos
+- array_search
+
+## Before
+
+```php
+if (strpos($var, "a")) { // AmbiguousReturnCheck: Use the === operator for testing a function that returns falsy value.
+    echo "`a` is found.";
+}
+```
+
+## After
+
+```php
+if (strpos($var, "a") !== false) {
+    echo "`a` is found.";
+}
+```
+
+## Reference
+
+- https://secure.php.net/manual/en/function.strpos.php
+- https://secure.php.net/manual/en/function.mb-strpos.php
+- https://secure.php.net/manual/en/function.stripos.php
+- https://secure.php.net/manual/en/function.mb-stripos.php
+- https://secure.php.net/manual/en/function.strrpos.php
+- https://secure.php.net/manual/en/function.mb-strrpos.php
+- https://secure.php.net/manual/en/function.array-search.php

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,4 @@
 - [DuplicateKey](DuplicateKey.md)
 - [UnreachableCatch](UnreachableCatch.md)
 - [DuplicateCaseCondition](DuplicateCaseCondition.md)
+- [AmbiguousReturnCheck](AmbiguousReturnCheck.md)

--- a/src/Tool/AmbiguousReturnCheck.php
+++ b/src/Tool/AmbiguousReturnCheck.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+namespace Pahout\Tool;
+
+use \ast\Node;
+use Pahout\Logger;
+use Pahout\Hint;
+
+/**
+* Detect a testing of return value of function not using the `===` operator.
+*
+* In functions returning falsy value, do not compare return values ​​without using the `===` operator.
+* For example, `strpos` returns integer or false, so if you check this with the `==` operator,
+* when returning 0, the condition is the same as false.
+*
+* ## Before
+*
+* ```
+* if (strpos($var, "a")) {
+*     echo "`a` is found.";
+* }
+* ```
+*
+* ## After
+*
+* ```
+* if (strpos($var, "a") !== false) {
+*     echo "`a` is found.";
+* }
+* ```
+*
+*/
+class AmbiguousReturnCheck implements Base
+{
+    use Howdah;
+
+    public const ENTRY_POINT = \ast\AST_IF_ELEM;
+    public const PHP_VERSION = '0.0.0';
+    public const HINT_TYPE = "AmbiguousReturnCheck";
+    private const HINT_MESSAGE = "Use the === operator for testing a function that returns falsy value.";
+    private const HINT_LINK = Hint::DOCUMENT_LINK."/AmbiguousReturnCheck.md";
+    private const FUNCTION_LIST = [
+        'strpos',
+        'mb_strpos',
+        'stripos',
+        'mb_stripos',
+        'strrpos',
+        'mb_strrpos',
+        'array_search'
+    ];
+
+    /**
+    * Detect a testing of return value of function not using the `===` operator.
+    *
+    * @param string $file File name to be analyzed.
+    * @param Node   $node AST node to be analyzed.
+    * @return Hint[] List of hints obtained from results.
+    */
+    public function run(string $file, Node $node): array
+    {
+        $hints = [];
+
+        $cond = $node->children['cond'];
+        if (!($cond instanceof Node)) {
+            return [];
+        }
+
+        foreach (self::FUNCTION_LIST as $function) {
+            // if (strpos(var, str))
+            if ($this->isFunctionCall($cond, $function)) {
+                $hints[] = new Hint(
+                    self::HINT_TYPE,
+                    self::HINT_MESSAGE,
+                    $file,
+                    $cond->lineno,
+                    self::HINT_LINK
+                );
+            }
+
+            // if (!strpos(var, str))
+            if ($cond->kind === \ast\AST_UNARY_OP && $cond->flags === \ast\flags\UNARY_BOOL_NOT) {
+                $expr = $cond->children['expr'];
+
+                if ($this->isFunctionCall($expr, $function)) {
+                    $hints[] = new Hint(
+                        self::HINT_TYPE,
+                        self::HINT_MESSAGE,
+                        $file,
+                        $expr->lineno,
+                        self::HINT_LINK
+                    );
+                }
+            }
+
+            // if (strpos(var, str) == val || val == strpos(var, str))
+            // if (strpos(var, str) != val || val != strpos(var, str))
+            if ($cond->kind === \ast\AST_BINARY_OP && in_array($cond->flags, [\ast\flags\BINARY_IS_EQUAL, \ast\flags\BINARY_IS_NOT_EQUAL], true)) {
+                $left = $cond->children['left'];
+                $right = $cond->children['right'];
+
+                if ($this->isFunctionCall($left, $function) || $this->isFunctionCall($right, $function)) {
+                    $hints[] = new Hint(
+                        self::HINT_TYPE,
+                        self::HINT_MESSAGE,
+                        $file,
+                        $cond->lineno,
+                        self::HINT_LINK
+                    );
+                }
+            }
+        }
+
+        return $hints;
+    }
+}

--- a/src/Tool/EscapeShellArg.php
+++ b/src/Tool/EscapeShellArg.php
@@ -34,6 +34,8 @@ use Pahout\Hint;
 */
 class EscapeShellArg implements Base
 {
+    use Howdah;
+
     /** Analyze function call declarations (AST_CALL) */
     public const ENTRY_POINT = \ast\AST_CALL;
     /** PHP version to enable this tool */
@@ -51,22 +53,14 @@ class EscapeShellArg implements Base
     */
     public function run(string $file, Node $node): array
     {
-        $expr = $node->children['expr'];
-
-        if ($expr->kind === \ast\AST_NAME) {
-            if ($expr->children['name'] === 'escapeshellcmd') {
-                return [new Hint(
-                    self::HINT_TYPE,
-                    self::HINT_MESSAGE,
-                    $file,
-                    $node->lineno,
-                    self::HINT_LINK
-                )];
-            } else {
-                Logger::getInstance()->debug('Ignore function name: '.$expr->children['name']);
-            }
-        } else {
-            Logger::getInstance()->debug('Ignore AST kind: '.$expr->kind);
+        if ($this->isFunctionCall($node, 'escapeshellcmd')) {
+            return [new Hint(
+                self::HINT_TYPE,
+                self::HINT_MESSAGE,
+                $file,
+                $node->lineno,
+                self::HINT_LINK
+            )];
         }
 
         return [];

--- a/src/Tool/Howdah.php
+++ b/src/Tool/Howdah.php
@@ -38,4 +38,24 @@ trait Howdah
 
         return true;
     }
+
+    /**
+    * Verify that node is AST_CALL of the specified function name.
+    *
+    * @param mixed  $node     Node or others.
+    * @param string $function A function name.
+    * @return boolean Result.
+    */
+    public function isFunctionCall($node, string $function): Bool
+    {
+        if ($node instanceof Node && $node->kind === \ast\AST_CALL) {
+            $expr = $node->children['expr'];
+
+            if ($expr->kind === \ast\AST_NAME && $expr->children['name'] === $function) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Tool/InstanceConstant.php
+++ b/src/Tool/InstanceConstant.php
@@ -30,6 +30,8 @@ use Pahout\Hint;
 */
 class InstanceConstant implements Base
 {
+    use Howdah;
+
     /** Analyze calling class constants (AST_CLASS_CONST) */
     public const ENTRY_POINT = \ast\AST_CLASS_CONST;
     /** PHP version to enable this tool */
@@ -49,25 +51,14 @@ class InstanceConstant implements Base
     {
         $klass = $node->children['class'];
 
-        if ($klass->kind === \ast\AST_CALL) {
-            $expr = $klass->children['expr'];
-            if ($expr->kind === \ast\AST_NAME) {
-                if ($expr->children['name'] === 'get_class') {
-                    return [new Hint(
-                        self::HINT_TYPE,
-                        self::HINT_MESSAGE,
-                        $file,
-                        $klass->lineno,
-                        self::HINT_LINK
-                    )];
-                } else {
-                    Logger::getInstance()->debug('Ignore function name: '.$expr->children['name']);
-                }
-            } else {
-                Logger::getInstance()->debug('Ignore expr AST kind: '.$expr->kind);
-            }
-        } else {
-            Logger::getInstance()->debug('Ignore klass AST kind: '.$klass->kind);
+        if ($this->isFunctionCall($klass, 'get_class')) {
+            return [new Hint(
+                self::HINT_TYPE,
+                self::HINT_MESSAGE,
+                $file,
+                $klass->lineno,
+                self::HINT_LINK
+            )];
         }
 
         return [];

--- a/src/Tool/PasswordHash.php
+++ b/src/Tool/PasswordHash.php
@@ -28,6 +28,8 @@ use Pahout\Hint;
 */
 class PasswordHash implements Base
 {
+    use Howdah;
+
     /** Analyze function call (AST_CALL) */
     public const ENTRY_POINT = \ast\AST_CALL;
     /** PHP version to enable this tool */
@@ -45,18 +47,14 @@ class PasswordHash implements Base
     */
     public function run(string $file, Node $node): array
     {
-        $expr = $node->children['expr'];
-
-        if ($expr->kind === \ast\AST_NAME) {
-            if ($expr->children['name'] === 'crypt') {
-                return [new Hint(
-                    self::HINT_TYPE,
-                    self::HINT_MESSAGE,
-                    $file,
-                    $node->lineno,
-                    self::HINT_LINK
-                )];
-            }
+        if ($this->isFunctionCall($node, 'crypt')) {
+            return [new Hint(
+                self::HINT_TYPE,
+                self::HINT_MESSAGE,
+                $file,
+                $node->lineno,
+                self::HINT_LINK
+            )];
         }
 
         return [];

--- a/src/Tool/RandomInt.php
+++ b/src/Tool/RandomInt.php
@@ -28,6 +28,8 @@ use Pahout\Hint;
 */
 class RandomInt implements Base
 {
+    use Howdah;
+
     /** Analyze function call declarations (AST_CALL) */
     public const ENTRY_POINT = \ast\AST_CALL;
     /** PHP version to enable this tool */
@@ -46,10 +48,8 @@ class RandomInt implements Base
     */
     public function run(string $file, Node $node): array
     {
-        $expr = $node->children['expr'];
-
-        if ($expr->kind === \ast\AST_NAME) {
-            if (in_array($expr->children['name'], self::FUNCTION_LIST, true)) {
+        foreach (self::FUNCTION_LIST as $function) {
+            if ($this->isFunctionCall($node, $function)) {
                 return [new Hint(
                     self::HINT_TYPE,
                     self::HINT_MESSAGE,
@@ -57,11 +57,7 @@ class RandomInt implements Base
                     $node->lineno,
                     self::HINT_LINK
                 )];
-            } else {
-                Logger::getInstance()->debug('Ignore function name: '.$expr->children['name']);
             }
-        } else {
-            Logger::getInstance()->debug('Ignore AST kind: '.$expr->kind);
         }
 
         return [];

--- a/src/Tool/VariableLengthArgumentLists.php
+++ b/src/Tool/VariableLengthArgumentLists.php
@@ -40,6 +40,8 @@ use Pahout\Hint;
 */
 class VariableLengthArgumentLists implements Base
 {
+    use Howdah;
+
     /** Analyze function call declarations (AST_CALL) */
     public const ENTRY_POINT = \ast\AST_CALL;
     /** PHP version to enable this tool */
@@ -58,10 +60,8 @@ class VariableLengthArgumentLists implements Base
     */
     public function run(string $file, Node $node): array
     {
-        $expr = $node->children['expr'];
-
-        if ($expr->kind === \ast\AST_NAME) {
-            if (in_array($expr->children['name'], self::FUNCTION_LIST, true)) {
+        foreach (self::FUNCTION_LIST as $function) {
+            if ($this->isFunctionCall($node, $function)) {
                 return [new Hint(
                     self::HINT_TYPE,
                     self::HINT_MESSAGE,
@@ -69,11 +69,7 @@ class VariableLengthArgumentLists implements Base
                     $node->lineno,
                     self::HINT_LINK
                 )];
-            } else {
-                Logger::getInstance()->debug('Ignore function name: '.$expr->children['name']);
             }
-        } else {
-            Logger::getInstance()->debug('Ignore AST kind: '.$expr->kind);
         }
 
         return [];

--- a/src/ToolBox.php
+++ b/src/ToolBox.php
@@ -5,11 +5,11 @@ namespace Pahout;
 use Pahout\Tool\Base;
 
 /**
-* Factory of tools used by Mahout
+* Factory of tools used by Pahout
 */
 class ToolBox
 {
-    /** List of valid tool names used by Mahout */
+    /** List of valid tool names used by Pahout */
     public const VALID_TOOLS = [
         'ShortArraySyntax',
         'SyntaxError',
@@ -27,6 +27,7 @@ class ToolBox
         'DuplicateKey',
         'UnreachableCatch',
         'DuplicateCaseCondition',
+        'AmbiguousReturnCheck',
     ];
 
     /**

--- a/tests/Tool/AmbiguousReturnCheckTest.php
+++ b/tests/Tool/AmbiguousReturnCheckTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Pahout\Test\Tool;
+
+use PHPUnit\Framework\TestCase;
+use Pahout\Test\helper\PahoutHelper;
+use Pahout\Tool\AmbiguousReturnCheck;
+use Pahout\Hint;
+use Pahout\Logger;
+use Pahout\Config;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class AmbiguousReturnCheckTest extends TestCase
+{
+    public function setUp()
+    {
+        Logger::getInstance(new ConsoleOutput());
+    }
+
+    public function test_function_call()
+    {
+        $code = <<<'CODE'
+<?php
+if (strpos($var, "a")) {
+    something($var);
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new AmbiguousReturnCheck());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'AmbiguousReturnCheck',
+                    'Use the === operator for testing a function that returns falsy value.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/AmbiguousReturnCheck.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_unary_bool_not()
+    {
+        $code = <<<'CODE'
+<?php
+if (!strpos($var, "a")) {
+    something($var);
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new AmbiguousReturnCheck());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'AmbiguousReturnCheck',
+                    'Use the === operator for testing a function that returns falsy value.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/AmbiguousReturnCheck.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_equal_operator()
+    {
+        $code = <<<'CODE'
+<?php
+if (strpos($var, "a") == false) {
+    something($var);
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new AmbiguousReturnCheck());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'AmbiguousReturnCheck',
+                    'Use the === operator for testing a function that returns falsy value.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/AmbiguousReturnCheck.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_not_equal_operator()
+    {
+        $code = <<<'CODE'
+<?php
+if (strpos($var, "a") != false) {
+    something($var);
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new AmbiguousReturnCheck());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'AmbiguousReturnCheck',
+                    'Use the === operator for testing a function that returns falsy value.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/AmbiguousReturnCheck.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_identical_operator()
+    {
+        $code = <<<'CODE'
+<?php
+if (strpos($var, "a") === false) {
+    something($var);
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new AmbiguousReturnCheck());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_not_identical_operator()
+    {
+        $code = <<<'CODE'
+<?php
+if (strpos($var, "a") !== false) {
+    something($var);
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new AmbiguousReturnCheck());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+}


### PR DESCRIPTION
For example, `strpos` returns false when a second argument string is not included in a first argument.

```php
<?php

strpos("abc", "d"); # => false
```

However, this function may return falsy value. The example is as follows:

```php
<?php

strpos("abc", "a"); # => 0
```

In other words, unless you use the identical operator, you may get unintended results.

```php
<?php

if (strpos("abc", "a") == false) {
    echo "not found.";
}
```

This tool gives hints to the above code.