### PR TITLE
Handling array destructuring for DuplicateKey

### DIFF
--- a/src/Tool/DuplicateKey.php
+++ b/src/Tool/DuplicateKey.php
@@ -51,6 +51,10 @@ class DuplicateKey implements Base
         $keys = [];
 
         foreach ($node->children as $elem) {
+            if (is_null($elem)) {
+                continue;
+            }
+
             $key = $elem->children['key'];
             // If the array does not have key, ignores this element.
             if (!is_null($key)) {

--- a/tests/Tool/DuplicateKeyTest.php
+++ b/tests/Tool/DuplicateKeyTest.php
@@ -89,4 +89,22 @@ CODE;
 
         $this->assertEmpty($tester->hints);
     }
+
+    public function test_array_destructuring()
+    {
+        $code = <<<'CODE'
+<?php
+
+list('foo' => $a, 'bar' => $b) = $x;
+[$a, $b] = $x;
+['foo' => $a, 'bar' => $b] = $x;
+[, [$a]] = $x;
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new DuplicateKey());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
 }


### PR DESCRIPTION
The following example, the children of `AST_ARRAY` has `null`.

```php
<?php
[, [$a]] = $x;
```