### PR TITLE
Add new `--only-tools` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Options:
       --vendor[=VENDOR]              Check vendor directory [default: false]
   -f, --format[=FORMAT]              Output format [default: "pretty", possibles: "pretty", "json"]
   -c, --config[=CONFIG]              Config file path [default: ".pahout.yaml"]
+      --only-tools[=ONLY-TOOLS]      Check only the given tool types (multiple values allowed)
   -h, --help                         Display this help message
   -q, --quiet                        Do not output any message
   -V, --version                      Display this application version
@@ -153,6 +154,10 @@ If you use [phpenv](https://github.com/phpenv/phpenv), changes the default PHP v
 ### Ignore Tools
 
 In Pahout, what generates hints is called "Tool". You can specify the tool name you want to ignore. Please look at the documentation for the list of tool names.
+
+### Only Tools
+
+Contrary to `ignore_tools`, specify tools to check.
 
 ### Ignore Paths
 

--- a/src/Command/Check.php
+++ b/src/Command/Check.php
@@ -88,6 +88,12 @@ class Check extends Command
                  InputOption::VALUE_OPTIONAL,
                  'Config file path',
                  '.pahout.yaml'
+             )
+             ->addOption(
+                 'only-tools',
+                 null,
+                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                 'Check only the given tool types'
              );
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -5,6 +5,7 @@ namespace Pahout\Test;
 use PHPUnit\Framework\TestCase;
 use Pahout\Config;
 use Pahout\Logger;
+use Pahout\ToolBox;
 use Pahout\Exception\InvalidConfigFilePathException;
 use Pahout\Exception\InvalidConfigOptionException;
 use Pahout\Exception\InvalidConfigOptionValueException;
@@ -31,6 +32,7 @@ class ConfigTest extends TestCase
                 'ignore-paths' => null,
                 'vendor' => null,
                 'format' => null,
+                'only-tools' => null,
             ]);
             $config = Config::getInstance();
 
@@ -58,11 +60,12 @@ class ConfigTest extends TestCase
                 'ignore-paths' => ['tests'],
                 'vendor' => true,
                 'format' => 'json',
+                'only-tools' => array_diff(ToolBox::VALID_TOOLS, ['ElvisOperator']),
             ]);
             $config = Config::getInstance();
 
             $this->assertEquals('7.1.0', $config->php_version);
-            $this->assertEquals(['ShortArraySyntax'], $config->ignore_tools);
+            $this->assertEquals(['ShortArraySyntax', 'ElvisOperator'], array_values($config->ignore_tools));
             $this->assertEquals([
                 self::FIXTURE_PATH.'/with_config_file/tests/test1.php'
             ], $config->ignore_paths);
@@ -85,6 +88,7 @@ class ConfigTest extends TestCase
                 'ignore-paths' => null,
                 'vendor' => null,
                 'format' => null,
+                'only-tools' => null,
             ]);
             $config = Config::getInstance();
 
@@ -106,6 +110,7 @@ class ConfigTest extends TestCase
                 'ignore-paths' => null,
                 'vendor' => null,
                 'format' => null,
+                'only-tools' => null,
             ]);
             $config = Config::getInstance();
 
@@ -127,11 +132,12 @@ class ConfigTest extends TestCase
                 'ignore-paths' => null,
                 'vendor' => null,
                 'format' => null,
+                'only-tools' => null,
             ], 'custom_config.yaml');
             $config = Config::getInstance();
 
             $this->assertEquals('7.0.0', $config->php_version);
-            $this->assertEquals(['ShortArraySyntax'], $config->ignore_tools);
+            $this->assertEquals(['ShortArraySyntax'], array_values($config->ignore_tools));
             $this->assertEquals([
                 self::FIXTURE_PATH.'/with_config_file/tests/test1.php',
                 self::FIXTURE_PATH.'/with_config_file/bin/test1.php',
@@ -156,11 +162,12 @@ class ConfigTest extends TestCase
                 'ignore-paths' => ['tests'],
                 'vendor' => null,
                 'format' => null,
+                'only-tools' => null,
             ], 'custom_config.yaml');
             $config = Config::getInstance();
 
             $this->assertEquals('7.1.0', $config->php_version);
-            $this->assertEquals(['SyntaxError'], $config->ignore_tools);
+            $this->assertEquals(['SyntaxError'], array_values($config->ignore_tools));
             $this->assertEquals([
                 self::FIXTURE_PATH.'/with_config_file/tests/test1.php'
             ], $config->ignore_paths);
@@ -182,6 +189,7 @@ class ConfigTest extends TestCase
             'ignore-paths' => null,
             'vendor' => null,
             'format' => null,
+            'only-tools' => null,
         ], 'invalid_config_file.yaml');
     }
 
@@ -200,6 +208,7 @@ class ConfigTest extends TestCase
                 'ignore-paths' => null,
                 'vendor' => null,
                 'format' => null,
+                'only-tools' => null,
             ], 'invalid_config.yaml');
         } finally {
             chdir($work_dir);
@@ -217,10 +226,11 @@ class ConfigTest extends TestCase
             'ignore-paths' => null,
             'vendor' => null,
             'format' => null,
+            'only-tools' => null,
         ]);
     }
 
-    public function test_throw_exception_when_specified_an_invalid_tools()
+    public function test_throw_exception_when_specified_an_invalid_tools_as_ignore_tools()
     {
         $this->expectException(InvalidConfigOptionValueException::class);
         $this->expectExceptionMessage('`invalid_tool` is an invalid tool. Please check the correct tool list.');
@@ -231,6 +241,22 @@ class ConfigTest extends TestCase
             'ignore-paths' => null,
             'vendor' => null,
             'format' => null,
+            'only-tools' => null,
+        ]);
+    }
+
+    public function test_throw_exception_when_specified_an_invalid_tools_as_only_tools()
+    {
+        $this->expectException(InvalidConfigOptionValueException::class);
+        $this->expectExceptionMessage('`invalid_tool` is an invalid tool. Please check the correct tool list.');
+
+        Config::load([
+            'php-version' => null,
+            'ignore-tools' => null,
+            'ignore-paths' => null,
+            'vendor' => null,
+            'format' => null,
+            'only-tools' => ['invalid_tool'],
         ]);
     }
 
@@ -245,6 +271,7 @@ class ConfigTest extends TestCase
             'ignore-paths' => 'tests',
             'vendor' => null,
             'format' => null,
+            'only-tools' => null,
         ]);
     }
 
@@ -259,6 +286,7 @@ class ConfigTest extends TestCase
             'ignore-paths' => null,
             'vendor' => 'yes',
             'format' => null,
+            'only-tools' => null,
         ]);
     }
 
@@ -273,6 +301,7 @@ class ConfigTest extends TestCase
             'ignore-paths' => null,
             'vendor' => null,
             'format' => 'xml',
+            'only-tools' => null,
         ]);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -136,6 +136,31 @@ OUTPUT;
         }
     }
 
+    public function test_when_specified_only_tools()
+    {
+        $work_dir = getcwd();
+        try {
+            chdir(self::FIXTURE_PATH.'/not_receiving_any_files');
+            $command = new CommandTester(new Check());
+            $command->execute([
+                '--only-tools' => ['SyntaxError']
+            ]);
+
+            $expected = <<<OUTPUT
+./syntax_error.php:3
+\tSyntaxError: Syntax error occurred. [https://github.com/wata727/pahout/blob/master/docs/SyntaxError.md]
+
+3 files checked, 1 hints detected.
+
+OUTPUT;
+
+            $this->assertEquals($expected, $command->getDisplay());
+            $this->assertEquals(Check::EXIT_CODE_HINT_FOUND, $command->getStatusCode());
+        } finally {
+            chdir($work_dir);
+        }
+    }
+
     public function test_when_specified_ignore_paths()
     {
         $work_dir = getcwd();

--- a/tests/helpers/PahoutHelper.php
+++ b/tests/helpers/PahoutHelper.php
@@ -25,6 +25,7 @@ class PahoutHelper
             'ignore-paths' => null,
             'vendor' => null,
             'format' => null,
+            'only-tools' => null,
         ]);
         $pahout = new Pahout([]);
         $klass = new \ReflectionClass('\Pahout\Pahout');


### PR DESCRIPTION
When using `--only-tools` option, Pahout checks files by the given tools only. 

This option is useful for testing the impact of new tools.