### PR TITLE
Add new JSONThrowOnError tool

### DIFF
--- a/.pahout.yaml
+++ b/.pahout.yaml
@@ -1,0 +1,1 @@
+php_version: 7.1.0

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Arguments:
   files                              List of file names or directory names to be analyzed
 
 Options:
-      --php-version[=PHP-VERSION]    Target PHP version [default: "7.1.8"]
+      --php-version[=PHP-VERSION]    Target PHP version [default: "7.3.0"]
       --ignore-tools[=IGNORE-TOOLS]  Ignore tool types [default: Nothing to ignore] (multiple values allowed)
       --ignore-paths[=IGNORE-PATHS]  Ignore files and directories [default: Nothing to ignore] (multiple values allowed)
       --vendor[=VENDOR]              Check vendor directory [default: false]

--- a/docs/JSONThrowOnError.md
+++ b/docs/JSONThrowOnError.md
@@ -1,0 +1,28 @@
+# JSONThrowOnError
+
+PHP 7.3 makes it to easy to handle `json_*` function errors easily.  
+Previously, these function didn't throw an exception when an error occurred. But now, it throws `JsonException` if passed `JSON_THROW_ON_ERROR` as a option. This is a better way to handle errors.
+
+## Before
+
+```php
+json_decode("{");
+if (json_last_error() !== JSON_ERROR_NONE) {
+    echo "An error occurred";
+}
+```
+
+## After
+
+```php
+try {
+    json_decode("{", false, 512, JSON_THROW_ON_ERROR);
+} catch (JsonException $exn) {
+    echo "An error occurred";
+}
+```
+
+## Reference
+
+- https://secure.php.net/manual/en/function.json-decode.php
+- https://secure.php.net/manual/en/function.json-encode.php

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Pahout Hints
 
+## PHP 7.3.0
+
+- [JSONThrowOnError](JSONThrowOnError.md)
+
 ## PHP 7.1.0
 
 - [MultipleCatch](MultipleCatch.md)

--- a/src/Command/Check.php
+++ b/src/Command/Check.php
@@ -51,7 +51,7 @@ class Check extends Command
                  'php-version',
                  null,
                  InputOption::VALUE_OPTIONAL,
-                 'Target PHP version <comment>[default: "7.1.8"]</>',
+                 'Target PHP version <comment>[default: "7.3.0"]</>',
                  null
              )
              ->addOption(

--- a/src/Config.php
+++ b/src/Config.php
@@ -34,7 +34,7 @@ class Config
     /** @var string[] Ignore files or directories */
     public $ignore_paths = [];
 
-    /** @var bool Check vendor directory */
+    /** @var boolean Check vendor directory */
     public $vendor = false;
 
     /** @var string The name of formatter */

--- a/src/Config.php
+++ b/src/Config.php
@@ -26,7 +26,7 @@ class Config
     private static $config;
 
     /** @var string Target PHP version. default is latest version */
-    public $php_version = '7.1.8';
+    public $php_version = '7.3.0';
 
     /** @var string[] Ignore tool types */
     public $ignore_tools = [];

--- a/src/Tool/JSONThrowOnError.php
+++ b/src/Tool/JSONThrowOnError.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Pahout\Tool;
+
+use \ast\Node;
+use Pahout\Hint;
+
+/**
+* Check whether a `json_*` function has `JSON_THROW_ON_ERROR`
+*
+* PHP 7.3 makes it to easy to handle `json_*` function errors easily.
+* Previously, these function didn't throw an exception when an error occurred. But now, it throws `JsonException` if passed `JSON_THROW_ON_ERROR` as a option. This is a better way to handle errors.
+*
+* ## Before
+*
+* ```php
+* json_decode("{");
+* if (json_last_error() !== JSON_ERROR_NONE) {
+*     echo "An error occurred";
+* }
+* ```
+*
+* ## After
+*
+* ```php
+* try {
+*     json_decode("{", false, 512, JSON_THROW_ON_ERROR);
+* } catch (JsonException $exn) {
+*     echo "An error occurred";
+* }
+* ```
+*/
+class JSONThrowOnError implements Base
+{
+    use Howdah;
+
+    public const ENTRY_POINT = \ast\AST_CALL;
+    public const PHP_VERSION = '7.3.0';
+    public const HINT_TYPE = "JSONThrowOnError";
+    private const HINT_MESSAGE = 'Encourage to specify JSON_THROW_ON_ERROR option.';
+    private const HINT_LINK = Hint::DOCUMENT_LINK."/JSONThrowOnError.md";
+
+    /**
+    * Check whether a `json_*` function has `JSON_THROW_ON_ERROR`
+    *
+    * @param string $file File name to be analyzed.
+    * @param Node   $node AST node to be analyzed.
+    * @return Hint[] List of hints obtained from results.
+    */
+    public function run(string $file, Node $node): array
+    {
+        if ($this->isFunctionCall($node, 'json_decode')) {
+            $options = $node->children['args']->children[3] ?? null;
+            if ($this->shouldCheckOption($options) && !$this->isIncludeJSONThrowOnErrorOption($options)) {
+                return [new Hint(
+                    self::HINT_TYPE,
+                    self::HINT_MESSAGE,
+                    $file,
+                    $node->lineno,
+                    self::HINT_LINK
+                )];
+            }
+        }
+        if ($this->isFunctionCall($node, 'json_encode')) {
+            $options = $node->children['args']->children[1] ?? null;
+            if ($this->shouldCheckOption($options) && !$this->isIncludeJSONThrowOnErrorOption($options)) {
+                return [new Hint(
+                    self::HINT_TYPE,
+                    self::HINT_MESSAGE,
+                    $file,
+                    $node->lineno,
+                    self::HINT_LINK
+                )];
+            }
+        }
+
+        return [];
+    }
+
+    /**
+    * Check whether the passed options node should be checked.
+    *
+    * This function is used to suppress false positives.
+    *
+    * @param mixed $node Options node.
+    * @return boolean Result.
+    */
+    private function shouldCheckOption($node): Bool
+    {
+        if (!$node instanceof Node) {
+            return true;
+        }
+        if ($node->kind === \ast\AST_CONST) {
+            return true;
+        }
+        if ($node->kind === \ast\AST_BINARY_OP && $node->flags === \ast\flags\BINARY_BITWISE_OR) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+    * Check whether the passed node has `JSON_THROW_ON_ERROR`
+    *
+    * This function is also aware of inclusive or.
+    *
+    * @param mixed $node Node or others.
+    * @return boolean Result.
+    */
+    private function isIncludeJSONThrowOnErrorOption($node): Bool
+    {
+        if (!$node instanceof Node) {
+            return false;
+        }
+
+        if ($node->kind === \ast\AST_CONST) {
+            $name = $node->children["name"];
+            if ($name->kind === \ast\AST_NAME && $name->children["name"] === "JSON_THROW_ON_ERROR") {
+                return true;
+            }
+        }
+
+        if ($node->kind === \ast\AST_BINARY_OP && $node->flags === \ast\flags\BINARY_BITWISE_OR) {
+            return $this->isIncludeJSONThrowOnErrorOption($node->children["left"])
+                     || $this->isIncludeJSONThrowOnErrorOption($node->children["right"]);
+        }
+
+        return false;
+    }
+}

--- a/src/ToolBox.php
+++ b/src/ToolBox.php
@@ -29,6 +29,7 @@ class ToolBox
         'DuplicateCaseCondition',
         'LooseReturnCheck',
         'UnneededRegularExpression',
+        'JSONThrowOnError',
     ];
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -36,7 +36,7 @@ class ConfigTest extends TestCase
             ]);
             $config = Config::getInstance();
 
-            $this->assertEquals('7.1.8', $config->php_version);
+            $this->assertEquals('7.3.0', $config->php_version);
             $this->assertEmpty($config->ignore_tools);
             $this->assertEquals([
                 self::FIXTURE_PATH.'/with_vendor/vendor/test.php'

--- a/tests/Tool/JSONThrowOnErrorTest.php
+++ b/tests/Tool/JSONThrowOnErrorTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Pahout\Test\Tool;
+
+use PHPUnit\Framework\TestCase;
+use Pahout\Test\helper\PahoutHelper;
+use Pahout\Tool\JSONThrowOnError;
+use Pahout\Hint;
+use Pahout\Logger;
+use Pahout\Config;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class JSONThrowOnErrorTest extends TestCase
+{
+    public function setUp()
+    {
+        Logger::getInstance(new ConsoleOutput());
+    }
+
+    public function test_json_decode_without_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_decode($json);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'JSONThrowOnError',
+                    'Encourage to specify JSON_THROW_ON_ERROR option.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/JSONThrowOnError.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_json_decode_with_json_throw_on_error_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_json_decode_with_other_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_decode($json, false, 512, JSON_BIGINT_AS_STRING);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'JSONThrowOnError',
+                    'Encourage to specify JSON_THROW_ON_ERROR option.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/JSONThrowOnError.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_json_decode_with_multiple_other_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_decode($json, false, 512, JSON_BIGINT_AS_STRING | JSON_OBJECT_AS_ARRAY);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'JSONThrowOnError',
+                    'Encourage to specify JSON_THROW_ON_ERROR option.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/JSONThrowOnError.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_json_decode_with_multiple_json_throw_on_error_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_decode($json, false, 512, JSON_BIGINT_AS_STRING | JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_json_decode_with_variable_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_decode($json, false, 512, $options);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_json_encode_without_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_encode($json);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'JSONThrowOnError',
+                    'Encourage to specify JSON_THROW_ON_ERROR option.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/JSONThrowOnError.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_json_encode_with_json_throw_on_error_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_encode($json, JSON_THROW_ON_ERROR);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_json_encode_with_other_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_encode($json, JSON_FORCE_OBJECT);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'JSONThrowOnError',
+                    'Encourage to specify JSON_THROW_ON_ERROR option.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/JSONThrowOnError.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_json_encode_with_multiple_other_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_encode($json, JSON_FORCE_OBJECT | JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'JSONThrowOnError',
+                    'Encourage to specify JSON_THROW_ON_ERROR option.',
+                    './test.php',
+                    2,
+                    Hint::DOCUMENT_LINK.'/JSONThrowOnError.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_json_encode_with_multiple_json_throw_on_error_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_encode($json, JSON_FORCE_OBJECT | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_json_encode_with_variable_options()
+    {
+        $code = <<<'CODE'
+<?php
+json_encode($json, $options);
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new JSONThrowOnError());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+}


### PR DESCRIPTION
PHP 7.3 makes it to easy to handle `json_*` function errors easily.
Previously, these function didn't throw an exception when an error occurred. But now, it throws `JsonException` if passed `JSON_THROW_ON_ERROR` as a option. This is a better way to handle errors.

## Before

```php
json_decode("{");
if (json_last_error() !== JSON_ERROR_NONE) {
    echo "An error occurred";
}
```

## After

```php
try {
    json_decode("{", false, 512, JSON_THROW_ON_ERROR);
} catch (JsonException $exn) {
    echo "An error occurred";
}
```

## Reference

https://secure.php.net/manual/en/function.json-decode.php
https://secure.php.net/manual/en/function.json-encode.php