### PR TITLE
Add new DeclareStrictTypes tool

### DIFF
--- a/docs/DeclareStrictTypes.md
+++ b/docs/DeclareStrictTypes.md
@@ -1,0 +1,34 @@
+# DeclareStrictTypes
+
+Strict typing is introduced from PHP 7.0. Previously, PHP will coerce values into the expected scalar type even if the value type is wrong.  
+By declaring `strict_types` you can enable strict mode.
+
+## Before
+
+```php
+<?php // DeclareStrictTypes: Missing strict type declaration. The default types are not strict.
+
+function sum(int $a, int $b) {
+    return $a + $b;
+}
+
+var_dump(sum(1, 2));
+var_dump(sum(1.5, 2.5));
+```
+
+## After
+
+```php
+<?php declare(strict_types=1); // OK!
+
+function sum(int $a, int $b) {
+    return $a + $b;
+}
+
+var_dump(sum(1, 2));
+var_dump(sum(1.5, 2.5));
+```
+
+## Reference
+
+https://secure.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 
 - [NullCoalescingOperator](NullCoalescingOperator.md)
 - [RandomInt](RandomInt.md)
+- [DeclareStrictTypes](DeclareStrictTypes.md)
 
 ## PHP 5.6.0
 

--- a/src/Tool/DeclareStrictTypes.php
+++ b/src/Tool/DeclareStrictTypes.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace Pahout\Tool;
+
+use \ast\Node;
+use Pahout\Hint;
+
+/**
+* Check whether the script declares `strict_types` directive
+*
+* Strict typing is introduced from PHP 7.0. Previously, PHP will coerce values into the expected scalar type even if the value type is wrong.
+* By declaring `strict_types` you can enable strict mode.
+*
+* ## Before
+*
+* ```php
+* <?php
+*
+* function sum(int $a, int $b) {
+*     return $a + $b;
+* }
+*
+* var_dump(sum(1, 2));
+* var_dump(sum(1.5, 2.5));
+* ```
+*
+* ## After
+*
+* ```php
+* <?php declare(strict_types=1);
+*
+* function sum(int $a, int $b) {
+*     return $a + $b;
+* }
+*
+* var_dump(sum(1, 2));
+* var_dump(sum(1.5, 2.5));
+* ```
+*
+*/
+class DeclareStrictTypes implements Base
+{
+    public const ENTRY_POINT = \ast\AST_STMT_LIST;
+    public const PHP_VERSION = '7.0.0';
+    public const HINT_TYPE = "DeclareStrictTypes";
+    private const HINT_MESSAGE = 'Missing strict type declaration. The default types are not strict.';
+    private const HINT_LINK = Hint::DOCUMENT_LINK."/DeclareStrictTypes.md";
+
+    /** @var string Current inspection file. It is used only for top level inspection. */
+    private $inspectedFile;
+
+    /**
+    * Check whether the passed node has `strict_types` declaration.
+    *
+    * @param string $file File name to be analyzed.
+    * @param Node   $node AST node to be analyzed.
+    * @return Hint[] List of hints obtained from results.
+    */
+    public function run(string $file, Node $node): array
+    {
+        // This inspection only works to top level statements in each file.
+        if ($this->inspectedFile === $file) {
+            return [];
+        }
+
+        $found = false;
+        foreach ($node->children as $child) {
+            if (!$child instanceof Node) {
+                continue;
+            }
+
+            if ($child->kind !== \ast\AST_DECLARE) {
+                continue;
+            }
+
+            $declares = $child->children["declares"];
+            if ($declares->kind !== \ast\AST_CONST_DECL) {
+                continue;
+            }
+
+            foreach ($declares->children as $declare) {
+                if ($declare->kind === \ast\AST_CONST_ELEM && $declare->children["name"] === "strict_types") {
+                    $found = true;
+                }
+            }
+        }
+        $this->inspectedFile = $file;
+
+        if (!$found) {
+            return [new Hint(
+                self::HINT_TYPE,
+                self::HINT_MESSAGE,
+                $file,
+                $node->lineno,
+                self::HINT_LINK
+            )];
+        }
+
+        return [];
+    }
+}

--- a/src/ToolBox.php
+++ b/src/ToolBox.php
@@ -30,6 +30,7 @@ class ToolBox
         'LooseReturnCheck',
         'UnneededRegularExpression',
         'JSONThrowOnError',
+        'DeclareStrictTypes',
     ];
 
     /**

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 require_once __DIR__ . '/requirements.php';
 

--- a/src/requirements.php
+++ b/src/requirements.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 $php_version = phpversion();
 if (version_compare($php_version, '7.1.0', '<')) {

--- a/tests/Annotation/RebelTest.php
+++ b/tests/Annotation/RebelTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Annotation;
 

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test;
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test;
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test;
 

--- a/tests/Tool/ArrayPushShorthandTest.php
+++ b/tests/Tool/ArrayPushShorthandTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/DeclareStrictTypesTest.php
+++ b/tests/Tool/DeclareStrictTypesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/DeclareStrictTypesTest.php
+++ b/tests/Tool/DeclareStrictTypesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Pahout\Test\Tool;
+
+use PHPUnit\Framework\TestCase;
+use Pahout\Test\helper\PahoutHelper;
+use Pahout\Tool\DeclareStrictTypes;
+use Pahout\Hint;
+use Pahout\Logger;
+use Pahout\Config;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class DeclareStrictTypesTest extends TestCase
+{
+    public function setUp()
+    {
+        Logger::getInstance(new ConsoleOutput());
+    }
+
+    public function test_without_strict_types_declaration()
+    {
+        $code = <<<'CODE'
+<?php
+
+function sum(int $a, int $b) {
+    return $a + $b;
+}
+
+var_dump(sum(1, 2));
+var_dump(sum(1.5, 2.5));
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new DeclareStrictTypes());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'DeclareStrictTypes',
+                    'Missing strict type declaration. The default types are not strict.',
+                    './test.php',
+                    1,
+                    Hint::DOCUMENT_LINK.'/DeclareStrictTypes.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_with_strict_types_1_declaration()
+    {
+        $code = <<<'CODE'
+<?php
+declare(strict_types=1);
+
+function sum(int $a, int $b) {
+    return $a + $b;
+}
+
+var_dump(sum(1, 2));
+var_dump(sum(1.5, 2.5));
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new DeclareStrictTypes());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_with_strict_types_0_declaration()
+    {
+        $code = <<<'CODE'
+<?php
+declare(strict_types=0);
+
+function sum(int $a, int $b) {
+    return $a + $b;
+}
+
+var_dump(sum(1, 2));
+var_dump(sum(1.5, 2.5));
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new DeclareStrictTypes());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_with_ticks_declaration()
+    {
+        $code = <<<'CODE'
+<?php
+declare(ticks=1);
+
+function sum(int $a, int $b) {
+    return $a + $b;
+}
+
+var_dump(sum(1, 2));
+var_dump(sum(1.5, 2.5));
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new DeclareStrictTypes());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'DeclareStrictTypes',
+                    'Missing strict type declaration. The default types are not strict.',
+                    './test.php',
+                    1,
+                    Hint::DOCUMENT_LINK.'/DeclareStrictTypes.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+}

--- a/tests/Tool/DuplicateCaseConditionTest.php
+++ b/tests/Tool/DuplicateCaseConditionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/DuplicateKeyTest.php
+++ b/tests/Tool/DuplicateKeyTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/ElvisOperatorTest.php
+++ b/tests/Tool/ElvisOperatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/EscapeShellArgTest.php
+++ b/tests/Tool/EscapeShellArgTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/InstanceConstantTest.php
+++ b/tests/Tool/InstanceConstantTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/JSONThrowOnErrorTest.php
+++ b/tests/Tool/JSONThrowOnErrorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/LooseReturnCheckTest.php
+++ b/tests/Tool/LooseReturnCheckTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/MultipleCatchTest.php
+++ b/tests/Tool/MultipleCatchTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/NullCoalescingOperatorTest.php
+++ b/tests/Tool/NullCoalescingOperatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/PasswordHashTest.php
+++ b/tests/Tool/PasswordHashTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/RandomIntTest.php
+++ b/tests/Tool/RandomIntTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/RedundantTernaryOperatorTest.php
+++ b/tests/Tool/RedundantTernaryOperatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/ShortArraySyntaxTest.php
+++ b/tests/Tool/ShortArraySyntaxTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/SymmetricArrayDestructuringTest.php
+++ b/tests/Tool/SymmetricArrayDestructuringTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/UnneededRegularExpressionTest.php
+++ b/tests/Tool/UnneededRegularExpressionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/UnreachableCatchTest.php
+++ b/tests/Tool/UnreachableCatchTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/Tool/VariableLengthArgumentListsTest.php
+++ b/tests/Tool/VariableLengthArgumentListsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\Tool;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 require_once __DIR__.'/helpers/PahoutHelper.php';

--- a/tests/fixtures/not_receiving_any_files/subdir/test.php
+++ b/tests/fixtures/not_receiving_any_files/subdir/test.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(
     1, // ShortArraySyntax

--- a/tests/fixtures/not_receiving_any_files/syntax_error.php
+++ b/tests/fixtures/not_receiving_any_files/syntax_error.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 funcion f[] ( ... )

--- a/tests/fixtures/not_receiving_any_files/test.php
+++ b/tests/fixtures/not_receiving_any_files/test.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/rebel_annotations/test.php
+++ b/tests/fixtures/rebel_annotations/test.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /** @rebel ShortArraySyntax */
 $array = array(1, 2, 3);

--- a/tests/fixtures/receiving_files_and_dirs/subdir/test.php
+++ b/tests/fixtures/receiving_files_and_dirs/subdir/test.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/receiving_files_and_dirs/test1.php
+++ b/tests/fixtures/receiving_files_and_dirs/test1.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/receiving_files_and_dirs/test2.php
+++ b/tests/fixtures/receiving_files_and_dirs/test2.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/receiving_files_and_dirs/test3.php
+++ b/tests/fixtures/receiving_files_and_dirs/test3.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/with_default_config_file/test.php
+++ b/tests/fixtures/with_default_config_file/test.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/with_vendor/test.php
+++ b/tests/fixtures/with_vendor/test.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/with_vendor/vendor/test.php
+++ b/tests/fixtures/with_vendor/vendor/test.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 $array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/helpers/PahoutHelper.php
+++ b/tests/helpers/PahoutHelper.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Pahout\Test\helper;
 


### PR DESCRIPTION
Strict typing is introduced from PHP 7.0. Previously, PHP will coerce values into the expected scalar type even if the value type is wrong.
By declaring `strict_types` you can enable strict mode.

## Before

```php
<?php // DeclareStrictTypes: Missing strict type declaration. The default types are not strict.
function sum(int $a, int $b) {
    return $a + $b;
}
var_dump(sum(1, 2));
var_dump(sum(1.5, 2.5));
```

## After

```php
<?php declare(strict_types=1); // OK!
function sum(int $a, int $b) {
    return $a + $b;
}
var_dump(sum(1, 2));
var_dump(sum(1.5, 2.5));
```

## Reference

https://secure.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict