### PR TITLE
Add new IsCountable tool

### DIFF
--- a/docs/IsCountable.md
+++ b/docs/IsCountable.md
@@ -1,0 +1,27 @@
+# IsCountable
+
+`is_countable` function has been added in PHP 7.3. Previously, in order to check whether an object is countable or not, it was necessary to always check whether it is an array or it implements Countable interface.
+
+## Before
+
+```php
+<?php
+$obj = get_object();
+if (is_array($obj) || $obj instanceof Countable) { // IsCountable: You can use `is_countable` function instead.
+    // Something
+}
+```
+
+## After
+
+```php
+<?php
+$obj = get_object();
+if (is_countable($obj)) { // OK!
+    // Something
+}
+```
+
+## Reference
+
+https://secure.php.net/manual/en/function.is-countable.php

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## PHP 7.3.0
 
 - [JSONThrowOnError](JSONThrowOnError.md)
+- [IsCountable](IsCountable.md)
 
 ## PHP 7.1.0
 

--- a/src/Tool/IsCountable.php
+++ b/src/Tool/IsCountable.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace Pahout\Tool;
+
+use \ast\Node;
+use Pahout\Hint;
+
+/**
+*
+*/
+class IsCountable implements Base
+{
+    use Howdah;
+
+    public const ENTRY_POINT = \ast\AST_BINARY_OP;
+    public const PHP_VERSION = '7.3.0';
+    public const HINT_TYPE = "IsCountable";
+    private const HINT_MESSAGE = 'You can use `is_countable` function instead.';
+    private const HINT_LINK = Hint::DOCUMENT_LINK."/IsCountable.md";
+
+    /**
+    * Check if there is `is_array($a) || $a instanceof Countable` regardless order
+    *
+    * @param string $file File name to be analyzed.
+    * @param Node   $node AST node to be analyzed.
+    * @return Hint[] List of hints obtained from results.
+    */
+    public function run(string $file, Node $node): array
+    {
+        if ($node->flags !== \ast\flags\BINARY_BOOL_OR) {
+            return [];
+        }
+
+        if ($this->isArrayAndInstanceOfCountable($node->children['left'], $node->children['right'])
+             || $this->isArrayAndInstanceOfCountable($node->children['right'], $node->children['left'])) {
+            return [new Hint(
+                self::HINT_TYPE,
+                self::HINT_MESSAGE,
+                $file,
+                $node->lineno,
+                self::HINT_LINK
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+    * Check if there is `is_array($a)` and `$a instanceof Countable` expr
+    *
+    * @param mixed $left  A node to be analyzed.
+    * @param mixed $right The other one.
+    * @return boolean Result.
+    */
+    private function isArrayAndInstanceOfCountable($left, $right): Bool
+    {
+        if (!($left instanceof Node && $right instanceof Node)) {
+            return false;
+        }
+
+        if (!$this->isFunctionCall($left, 'is_array')) {
+            return false;
+        }
+        $args = $left->children['args'];
+
+        if ($args->kind !== \ast\AST_ARG_LIST) {
+            return false;
+        }
+        $arg = $args->children[0];
+
+        if ($right->kind !== \ast\AST_INSTANCEOF) {
+            return false;
+        }
+        $expr = $right->children['expr'];
+        $class = $right->children['class'];
+
+        if ($class->kind === \ast\AST_NAME
+              && $class->children['name'] === "Countable"
+              && $this->isEqualsWithoutLineno($arg, $expr)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/ToolBox.php
+++ b/src/ToolBox.php
@@ -31,6 +31,7 @@ class ToolBox
         'UnneededRegularExpression',
         'JSONThrowOnError',
         'DeclareStrictTypes',
+        'IsCountable',
     ];
 
     /**

--- a/tests/Tool/IsCountableTest.php
+++ b/tests/Tool/IsCountableTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Pahout\Test\Tool;
+
+use PHPUnit\Framework\TestCase;
+use Pahout\Test\helper\PahoutHelper;
+use Pahout\Tool\IsCountable;
+use Pahout\Hint;
+use Pahout\Logger;
+use Pahout\Config;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class IsCountableTest extends TestCase
+{
+    public function setUp()
+    {
+        Logger::getInstance(new ConsoleOutput());
+    }
+
+    public function test_is_array_and_instanceof_countable()
+    {
+        $code = <<<'CODE'
+<?php
+$obj = get_object();
+if (is_array($obj) || $obj instanceof Countable) {
+    // Something
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new IsCountable());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'IsCountable',
+                    'You can use `is_countable` function instead.',
+                    './test.php',
+                    3,
+                    Hint::DOCUMENT_LINK.'/IsCountable.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_instanceof_countable_and_is_array()
+    {
+        $code = <<<'CODE'
+<?php
+$obj = get_object();
+if ($obj instanceof Countable || is_array($obj)) {
+    // Something
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new IsCountable());
+        $tester->test($root);
+
+        $this->assertEquals(
+            [
+                new Hint(
+                    'IsCountable',
+                    'You can use `is_countable` function instead.',
+                    './test.php',
+                    3,
+                    Hint::DOCUMENT_LINK.'/IsCountable.md'
+                )
+            ],
+            $tester->hints
+        );
+    }
+
+    public function test_instanceof_countable_and_is_array_with_other_variables()
+    {
+        $code = <<<'CODE'
+<?php
+$obj = get_object();
+$obj2 = get_object();
+if ($obj instanceof Countable || is_array($obj2)) {
+    // Something
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new IsCountable());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+
+    public function test_is_countable()
+    {
+        $code = <<<'CODE'
+<?php
+$obj = get_object();
+if (is_countable($obj)) {
+    // Something
+}
+CODE;
+        $root = \ast\parse_code($code, Config::AST_VERSION);
+
+        $tester = PahoutHelper::create(new IsCountable());
+        $tester->test($root);
+
+        $this->assertEmpty($tester->hints);
+    }
+}


### PR DESCRIPTION
`is_countable` function has been added in PHP 7.3. Previously, in order to check whether an object is countable or not, it was necessary to always check whether it is an array or it implements Countable interface.

## Before

```php
<?php
$obj = get_object();
if (is_array($obj) || $obj instanceof Countable) { // IsCountable: You can use `is_countable` function instead.
    // Something
}
```

## After

```php
<?php
$obj = get_object();
if (is_countable($obj)) { // OK!
    // Something
}
```

## Reference

https://secure.php.net/manual/en/function.is-countable.php
