### PR TITLE
Allow to parse PHP-standardized version

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -104,6 +104,62 @@ class ConfigTest extends TestCase
         }
     }
 
+    public function test_default_config_with_development_version()
+    {
+        $work_dir = getcwd();
+        try {
+            chdir(self::FIXTURE_PATH.'/with_vendor');
+
+            Config::load([
+                'php-version' => '7.4.0-dev',
+                'ignore-tools' => null,
+                'ignore-paths' => null,
+                'vendor' => null,
+                'format' => null,
+                'only-tools' => null,
+            ]);
+            $config = Config::getInstance();
+
+            $this->assertEquals('7.4.0', $config->php_version);
+            $this->assertEmpty($config->ignore_tools);
+            $this->assertEquals([
+                self::FIXTURE_PATH.'/with_vendor/vendor/test.php'
+            ], $config->ignore_paths);
+            $this->assertFalse($config->vendor);
+            $this->assertEquals('pretty', $config->format);
+        } finally {
+            chdir($work_dir);
+        }
+    }
+
+    public function test_default_config_with_RC_version()
+    {
+        $work_dir = getcwd();
+        try {
+            chdir(self::FIXTURE_PATH.'/with_vendor');
+
+            Config::load([
+                'php-version' => '4.3.2RC1',
+                'ignore-tools' => null,
+                'ignore-paths' => null,
+                'vendor' => null,
+                'format' => null,
+                'only-tools' => null,
+            ]);
+            $config = Config::getInstance();
+
+            $this->assertEquals('4.3.2', $config->php_version);
+            $this->assertEmpty($config->ignore_tools);
+            $this->assertEquals([
+                self::FIXTURE_PATH.'/with_vendor/vendor/test.php'
+            ], $config->ignore_paths);
+            $this->assertFalse($config->vendor);
+            $this->assertEquals('pretty', $config->format);
+        } finally {
+            chdir($work_dir);
+        }
+    }
+
     public function test_with_config_file()
     {
         $work_dir = getcwd();


### PR DESCRIPTION
Fixes #48 

Currently, Pahout cannot parse "PHP-standardized" version like the following:

```
7.4.0-dev
4.3.2RC1
```

This PR makes it to parse these according to [`version_compare`'s way](https://secure.php.net/manual/en/function.version-compare.php).  Actually, stability doesn't affect the behavior of Pahout, so it is simply ignored.