### PR TITLE
Add `--extensions` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ You can change the configuration from the command line.
 
 ```
 $ pahout --help
+Description:
+  A pair programming partner for writing better PHP
+
 Usage:
-  check [options] [--] [<files>]...
+  check [options] [--] [<files>...]
 
 Arguments:
   files                              List of file names or directory names to be analyzed
@@ -117,6 +120,7 @@ Options:
       --php-version[=PHP-VERSION]    Target PHP version [default: runtime version]
       --ignore-tools[=IGNORE-TOOLS]  Ignore tool types [default: Nothing to ignore] (multiple values allowed)
       --ignore-paths[=IGNORE-PATHS]  Ignore files and directories [default: Nothing to ignore] (multiple values allowed)
+      --extensions[=EXTENSIONS]      File extensions to be analyzed [default: php] (multiple values allowed)
       --vendor[=VENDOR]              Check vendor directory [default: false]
   -f, --format[=FORMAT]              Output format [default: "pretty", possibles: "pretty", "json"]
   -c, --config[=CONFIG]              Config file path [default: ".pahout.yaml"]
@@ -128,9 +132,6 @@ Options:
       --no-ansi                      Disable ANSI output
   -n, --no-interaction               Do not ask any interactive question
   -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
-
-Help:
-  A pair programming partner for writing better PHP
 ```
 
 You can also change the configuration by preparing a configuration file called `.pahout.yaml`.
@@ -142,6 +143,10 @@ ignore_tools:
 ignore_paths:
     - tests
     - bin
+extensions:
+    - php
+    - module
+    - inc
 vendor: true
 ```
 
@@ -160,6 +165,10 @@ Contrary to `ignore_tools`, specify tools to check.
 ### Ignore Paths
 
 You can specify the file or directory you want to ignore. If a directory name is specified, all files under that directory are ignored.
+
+### Extensions
+
+File extensions to be analyzed. Default is `php` only.
 
 ### Vendor
 

--- a/src/Command/Check.php
+++ b/src/Command/Check.php
@@ -69,6 +69,13 @@ class Check extends Command
                  null
              )
              ->addOption(
+                 'extensions',
+                 null,
+                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                 'File extensions to be analyzed <comment>[default: php]</>',
+                 null
+             )
+             ->addOption(
                  'vendor',
                  null,
                  InputOption::VALUE_OPTIONAL,

--- a/src/Config.php
+++ b/src/Config.php
@@ -34,6 +34,9 @@ class Config
     /** @var string[] Ignore files or directories */
     public $ignore_paths = [];
 
+    /** @var string[] File extensions to be analyzed */
+    public $extensions = ["php"];
+
     /** @var boolean Check vendor directory */
     public $vendor = false;
 
@@ -105,6 +108,9 @@ class Config
         if ($arguments['ignore-paths']) {
             self::setOption('ignore_paths', $arguments['ignore-paths']);
         }
+        if ($arguments['extensions']) {
+            self::setOption('extensions', $arguments['extensions']);
+        }
         if ($arguments['vendor']) {
             self::setOption('vendor', $arguments['vendor']);
         }
@@ -128,11 +134,12 @@ class Config
         // Resolve ignore_paths to file name and reset.
         self::$config->ignore_paths = array_map(function ($path) {
             return realpath($path);
-        }, Loader::dig(self::$config->ignore_paths));
+        }, Loader::dig(self::$config->ignore_paths, self::$config));
 
         Logger::getInstance()->info('PHP version: '.self::$config->php_version);
         Logger::getInstance()->info('Ignore tools: '.var_export(self::$config->ignore_tools, true));
         Logger::getInstance()->info('Ignore paths: '.var_export(self::$config->ignore_paths, true));
+        Logger::getInstance()->info('Extensions: '.var_export(self::$config->extensions, true));
         Logger::getInstance()->info('Vendor: '.var_export(self::$config->vendor, true));
         Logger::getInstance()->info('Format: '.self::$config->format);
     }
@@ -219,6 +226,13 @@ class Config
                     throw new InvalidConfigOptionValueException('`'.$value.'` is invalid paths. It must be array.');
                 }
                 self::$config->ignore_paths = $value;
+                break;
+            // Extensions is must be array of extension.
+            case 'extensions':
+                if (!is_array($value)) {
+                    throw new InvalidConfigOptionValueException('`'.$value.'` is invalid extensions. It must be array.');
+                }
+                self::$config->extensions = $value;
                 break;
             // Vendor flag must be boolean.
             case 'vendor':

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -2,6 +2,7 @@
 
 namespace Pahout;
 
+use Pahout\Config;
 use Pahout\Exception\InvalidFilePathException;
 
 /**
@@ -14,13 +15,15 @@ class Loader
     *
     * If a directory name received, it digs recursively under the directory.
     *
-    * @param string[] $files List of file names and directory names to load.
+    * @param string[] $files  List of file names and directory names to load.
+    * @param Config   $config Application config.
     * @throws InvalidFilePathException Exception when the specified file or directory does not exist.
     * @return string[] List of readable file paths.
     */
-    public static function dig(array $files): array
+    public static function dig(array $files, Config $config): array
     {
         $list = [];
+        $pattern = implode("|", array_map("preg_quote", $config->extensions));
 
         foreach ($files as $file) {
             Logger::getInstance()->info('Load: '.$file);
@@ -30,7 +33,7 @@ class Loader
                 Logger::getInstance()->debug($file.' is directory. Recursively search the file list.');
                 $iterator = new \RegexIterator(
                     new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($file)),
-                    '/^.+\.php$/i'
+                    "{^.+\.$pattern$}i"
                 );
 
                 foreach ($iterator as $file_obj) {

--- a/src/Pahout.php
+++ b/src/Pahout.php
@@ -39,7 +39,7 @@ class Pahout
 
         $config = Config::getInstance();
         // Set a list of analysis target files.
-        $this->files = array_filter(Loader::dig($files), function ($file) use ($config) {
+        $this->files = array_filter(Loader::dig($files, $config), function ($file) use ($config) {
             return !in_array(realpath($file), $config->ignore_paths);
         });
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -30,6 +30,7 @@ class ConfigTest extends TestCase
                 'php-version' => null,
                 'ignore-tools' => null,
                 'ignore-paths' => null,
+                'extensions' => null,
                 'vendor' => null,
                 'format' => null,
                 'only-tools' => null,
@@ -41,6 +42,7 @@ class ConfigTest extends TestCase
             $this->assertEquals([
                 self::FIXTURE_PATH.'/with_vendor/vendor/test.php'
             ], $config->ignore_paths);
+            $this->assertEquals(['php'], $config->extensions);
             $this->assertFalse($config->vendor);
             $this->assertEquals('pretty', $config->format);
         } finally {
@@ -58,6 +60,7 @@ class ConfigTest extends TestCase
                 'php-version' => '7.1.0',
                 'ignore-tools' => ['ShortArraySyntax'],
                 'ignore-paths' => ['tests'],
+                'extensions' => ['php', 'module', 'inc'],
                 'vendor' => true,
                 'format' => 'json',
                 'only-tools' => array_diff(ToolBox::VALID_TOOLS, ['ElvisOperator']),
@@ -69,6 +72,7 @@ class ConfigTest extends TestCase
             $this->assertEquals([
                 self::FIXTURE_PATH.'/with_config_file/tests/test1.php'
             ], $config->ignore_paths);
+            $this->assertEquals(['php', 'module', 'inc'], $config->extensions);
             $this->assertTrue($config->vendor);
             $this->assertEquals('json', $config->format);
         } finally {
@@ -86,6 +90,7 @@ class ConfigTest extends TestCase
                 'php-version' => '7.1.25',
                 'ignore-tools' => null,
                 'ignore-paths' => null,
+                'extensions' => null,
                 'vendor' => null,
                 'format' => null,
                 'only-tools' => null,
@@ -114,6 +119,7 @@ class ConfigTest extends TestCase
                 'php-version' => '7.4.0-dev',
                 'ignore-tools' => null,
                 'ignore-paths' => null,
+                'extensions' => null,
                 'vendor' => null,
                 'format' => null,
                 'only-tools' => null,
@@ -142,6 +148,7 @@ class ConfigTest extends TestCase
                 'php-version' => '4.3.2RC1',
                 'ignore-tools' => null,
                 'ignore-paths' => null,
+                'extensions' => null,
                 'vendor' => null,
                 'format' => null,
                 'only-tools' => null,
@@ -170,6 +177,7 @@ class ConfigTest extends TestCase
                 'php-version' => null,
                 'ignore-tools' => null,
                 'ignore-paths' => null,
+                'extensions' => null,
                 'vendor' => null,
                 'format' => null,
                 'only-tools' => null,
@@ -183,6 +191,7 @@ class ConfigTest extends TestCase
                 self::FIXTURE_PATH.'/with_config_file/bin/test1.php',
                 self::FIXTURE_PATH.'/with_config_file/bin/test2.php',
             ], $config->ignore_paths);
+            $this->assertEquals(["php", "module", "inc"], $config->extensions);
             $this->assertTrue($config->vendor);
             $this->assertEquals('pretty', $config->format);
         } finally {
@@ -200,6 +209,7 @@ class ConfigTest extends TestCase
                 'php-version' => '7.1.0',
                 'ignore-tools' => ['SyntaxError'],
                 'ignore-paths' => ['tests'],
+                'extensions' => null,
                 'vendor' => null,
                 'format' => null,
                 'only-tools' => null,
@@ -227,6 +237,7 @@ class ConfigTest extends TestCase
             'php-version' => null,
             'ignore-tools' => null,
             'ignore-paths' => null,
+            'extensions' => null,
             'vendor' => null,
             'format' => null,
             'only-tools' => null,
@@ -246,6 +257,7 @@ class ConfigTest extends TestCase
                 'php-version' => null,
                 'ignore-tools' => null,
                 'ignore-paths' => null,
+                'extensions' => null,
                 'vendor' => null,
                 'format' => null,
                 'only-tools' => null,
@@ -264,6 +276,7 @@ class ConfigTest extends TestCase
             'php-version' => '7.1',
             'ignore-tools' => null,
             'ignore-paths' => null,
+            'extensions' => null,
             'vendor' => null,
             'format' => null,
             'only-tools' => null,
@@ -279,6 +292,7 @@ class ConfigTest extends TestCase
             'php-version' => null,
             'ignore-tools' => ['invalid_tool'],
             'ignore-paths' => null,
+            'extensions' => null,
             'vendor' => null,
             'format' => null,
             'only-tools' => null,
@@ -294,6 +308,7 @@ class ConfigTest extends TestCase
             'php-version' => null,
             'ignore-tools' => null,
             'ignore-paths' => null,
+            'extensions' => null,
             'vendor' => null,
             'format' => null,
             'only-tools' => ['invalid_tool'],
@@ -309,6 +324,23 @@ class ConfigTest extends TestCase
             'php-version' => null,
             'ignore-tools' => null,
             'ignore-paths' => 'tests',
+            'extensions' => null,
+            'vendor' => null,
+            'format' => null,
+            'only-tools' => null,
+        ]);
+    }
+
+    public function test_throw_exception_when_specified_an_invalid_extensions()
+    {
+        $this->expectException(InvalidConfigOptionValueException::class);
+        $this->expectExceptionMessage('`php` is invalid extensions. It must be array.');
+
+        Config::load([
+            'php-version' => null,
+            'ignore-tools' => null,
+            'ignore-paths' => null,
+            'extensions' => "php",
             'vendor' => null,
             'format' => null,
             'only-tools' => null,
@@ -324,6 +356,7 @@ class ConfigTest extends TestCase
             'php-version' => null,
             'ignore-tools' => null,
             'ignore-paths' => null,
+            'extensions' => null,
             'vendor' => 'yes',
             'format' => null,
             'only-tools' => null,
@@ -339,6 +372,7 @@ class ConfigTest extends TestCase
             'php-version' => null,
             'ignore-tools' => null,
             'ignore-paths' => null,
+            'extensions' => null,
             'vendor' => null,
             'format' => 'xml',
             'only-tools' => null,

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -351,4 +351,30 @@ OUTPUT;
             chdir($work_dir);
         }
     }
+
+    public function test_when_specified_extensions_and_ignore_paths()
+    {
+        $work_dir = getcwd();
+        try {
+            chdir(self::FIXTURE_PATH.'/not_receiving_any_files');
+            $command = new CommandTester(new Check());
+            $command->execute([
+                '--extensions' => ['php7'],
+                '--ignore-paths' => ['subdir']
+            ]);
+
+            $expected = <<<OUTPUT
+./test.php7:3
+\tShortArraySyntax: Use [...] syntax instead of array(...) syntax. [https://github.com/wata727/pahout/blob/master/docs/ShortArraySyntax.md]
+
+1 files checked, 1 hints detected.
+
+OUTPUT;
+
+            $this->assertEquals($expected, $command->getDisplay());
+            $this->assertEquals(Check::EXIT_CODE_HINT_FOUND, $command->getStatusCode());
+        } finally {
+            chdir($work_dir);
+        }
+    }
 }

--- a/tests/fixtures/not_receiving_any_files/subdir/test.php7
+++ b/tests/fixtures/not_receiving_any_files/subdir/test.php7
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+$array = array(
+    1, // ShortArraySyntax
+    2, 
+    3,
+);

--- a/tests/fixtures/not_receiving_any_files/test.php7
+++ b/tests/fixtures/not_receiving_any_files/test.php7
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+$array = array(1, 2, 3); // ShortArraySyntax

--- a/tests/fixtures/with_config_file/custom_config.yaml
+++ b/tests/fixtures/with_config_file/custom_config.yaml
@@ -4,4 +4,8 @@ ignore_tools:
 ignore_paths:
     - tests
     - bin
+extensions:
+    - php
+    - module
+    - inc
 vendor: true

--- a/tests/helpers/PahoutHelper.php
+++ b/tests/helpers/PahoutHelper.php
@@ -23,6 +23,7 @@ class PahoutHelper
             'php-version' => null,
             'ignore-tools' => null,
             'ignore-paths' => null,
+            'extensions' => null,
             'vendor' => null,
             'format' => null,
             'only-tools' => null,


### PR DESCRIPTION
Fixes #50 

This PR introduces a new option `--extensions`. This option allows specifying files to be analyzed. Previously, only files with `php` extension were analyzed at all times.

Example:

```
$ pahout --extensions php --extensions module --extensions inc
```